### PR TITLE
Installed OpenZeppelin library 

### DIFF
--- a/MetaCoin/.gitignore
+++ b/MetaCoin/.gitignore
@@ -1,0 +1,2 @@
+node_modules/
+build/

--- a/MetaCoin/package-lock.json
+++ b/MetaCoin/package-lock.json
@@ -1,0 +1,13 @@
+{
+  "name": "MetaCoin",
+  "version": "1.0.0",
+  "lockfileVersion": 1,
+  "requires": true,
+  "dependencies": {
+    "openzeppelin-solidity": {
+      "version": "1.12.0",
+      "resolved": "https://registry.npmjs.org/openzeppelin-solidity/-/openzeppelin-solidity-1.12.0.tgz",
+      "integrity": "sha512-WlorzMXIIurugiSdw121RVD5qA3EfSI7GybTn+/Du0mPNgairjt29NpVTAaH8eLjAeAwlw46y7uQKy0NYem/gA=="
+    }
+  }
+}

--- a/MetaCoin/package.json
+++ b/MetaCoin/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "MetaCoin",
+  "version": "1.0.0",
+  "description": "",
+  "main": "truffle-config.js",
+  "directories": {
+    "test": "test"
+  },
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "dependencies": {
+    "openzeppelin-solidity": "1.12.0"
+  }
+}


### PR DESCRIPTION
- Installed the OpenZeppelin library as a project dependency.
- Created a .gitignore file to ignore /build and /node_modules folders